### PR TITLE
Link against the CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,8 @@ cmake_minimum_required(VERSION 3.3)
 project(HelloWorld)
 
 find_package(SCIP REQUIRED)
-include_directories(${SCIP_INCLUDE_DIRS})
 
 add_executable(clique
    src/clique.c)
 
-target_link_libraries(clique ${SCIP_LIBRARIES})
+target_link_libraries(clique libscip)


### PR DESCRIPTION
When given a CMake target (such as `libscip`),`target_link_library` will add not only the headers and link flags, but all other information, such as public macros, necessary compiler arguments, transitive targets...